### PR TITLE
Modify defaults to prevent warnings from being added to the test output

### DIFF
--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/LocalOpenSearchCluster.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/LocalOpenSearchCluster.java
@@ -468,6 +468,8 @@ public class LocalOpenSearchCluster {
 					.put("discovery.initial_state_timeout", "8s").putList("discovery.seed_hosts", seedHosts).put("transport.tcp.port", transportPort)
 					.put("http.port", httpPort).put("cluster.routing.allocation.disk.threshold_enabled", false)
 					.put("discovery.probe.connect_timeout", "10s").put("discovery.probe.handshake_timeout", "10s").put("http.cors.enabled", true)
+					.put("plugins.security.compliance.salt", "1234567890123456")
+					.put("plugins.security.audit.type", "noop")
 					.build();
 		}
 


### PR DESCRIPTION
### Description

Removes the following messages from the output:
```
2022-08-25 12:51:21 SUITE-SecurityRolesTests-seed#[BB25A03A663EB2F7] WARN  Salt:48 - If you plan to use field masking pls configure compliance salt e1ukloTsQlOgPquJ to be a random string of 16 chars length identical on all nodes
2022-08-25 12:51:21 SUITE-SecurityRolesTests-seed#[BB25A03A663EB2F7] ERROR SinkProvider:64 - Default endpoint could not be created, auditlog will not work properly.
2022-08-25 12:51:21 SUITE-SecurityRolesTests-seed#[BB25A03A663EB2F7] WARN  AuditMessageRouter:61 - No default storage available, audit log may not work properly. Please check configuration.
```
Signed-off-by: Peter Nied <petern@amazon.com>

### Testing
Verified updated test output

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
